### PR TITLE
Log to specified directory in launch_and_output_to_files.

### DIFF
--- a/launchpad/launch/run_locally/launch_local_output_to_files.py
+++ b/launchpad/launch/run_locally/launch_local_output_to_files.py
@@ -36,9 +36,9 @@ def launch_and_output_to_files(commands_to_launch):
   titles = []
   manager = worker_manager.WorkerManager()
   atexit.register(manager.wait)
-  print('Logs are being output to: {}. '
+  print(f'Logs are being output to: {_LOGGING_DIR}. '
         'The logging directory can be customized by setting the '
-        'LAUNCHPAD_LOGGING_DIR environment variable.'.format(_LOGGING_DIR))
+        'LAUNCHPAD_LOGGING_DIR environment variable.')
   for command_to_launch in commands_to_launch:
     env = {}
     env.update(os.environ)
@@ -53,7 +53,7 @@ def launch_and_output_to_files(commands_to_launch):
     directory = os.path.dirname(filename)
     if not os.path.exists(directory):
       os.makedirs(directory)
-    print('Logging to: {}'.format(filename))
+    print(f'Logging to: {filename}')
     with open(filename, 'w') as outfile:
       manager.process_worker(
           command_to_launch.title, command_to_launch.command_as_list,

--- a/launchpad/launch/run_locally/launch_local_output_to_files.py
+++ b/launchpad/launch/run_locally/launch_local_output_to_files.py
@@ -26,6 +26,7 @@ if 'LAUNCHPAD_LOGGING_DIR' in os.environ:
 else:
     _LOGGING_DIR = '/tmp/launchpad_out/'
 
+
 def launch_and_output_to_files(commands_to_launch):
   """Launch commands given as CommandToLaunch and log the outputs to files.
 
@@ -35,6 +36,9 @@ def launch_and_output_to_files(commands_to_launch):
   titles = []
   manager = worker_manager.WorkerManager()
   atexit.register(manager.wait)
+  print('Logs are being output to: {}. '
+        'The logging directory can be customized by setting the '
+        'LAUNCHPAD_LOGGING_DIR environment variable.'.format(_LOGGING_DIR))
   for command_to_launch in commands_to_launch:
     env = {}
     env.update(os.environ)

--- a/launchpad/launch/run_locally/launch_local_output_to_files.py
+++ b/launchpad/launch/run_locally/launch_local_output_to_files.py
@@ -20,8 +20,11 @@ import os
 
 from launchpad.launch import worker_manager
 
-_LOGGING_DIR = '/tmp/launchpad_out/'
-
+# Use environment variable to direct logging to specified directory.
+if 'LAUNCHPAD_LOGGING_DIR' in os.environ:
+    _LOGGING_DIR = os.environ['LAUNCHPAD_LOGGING_DIR']
+else:
+    _LOGGING_DIR = '/tmp/launchpad_out/'
 
 def launch_and_output_to_files(commands_to_launch):
   """Launch commands given as CommandToLaunch and log the outputs to files.


### PR DESCRIPTION
A tiny but useful tweak allowing to optionally save the log files to a specified directory (rather than to the default directory `/tmp/launchpad_out/`) when the `terminal` argument of `lp.launch` is set to `terminal='output_to_files'`. The directory is passed with `LAUNCHPAD_LOGGING_DIR` environment variable.